### PR TITLE
Fix grammar mistake in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/886513e64fc6fbc107a7/maintainability)](https://codeclimate.com/github/pawelnvk/react-dropout/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/886513e64fc6fbc107a7/test_coverage)](https://codeclimate.com/github/pawelnvk/react-dropout/test_coverage)
 
-Easy way of managing navigation in react based apps.
+Easy way of managing navigation in react-based apps.
 
 ## Usage
 ```jsx


### PR DESCRIPTION
Multi-word adjectives (see what I did there? 😄) should use hyphens.

http://blog.esllibrary.com/2013/01/10/when-to-use-hyphens-rules-for-multiple-word-adjectives/